### PR TITLE
Preserve exception chains in strategy classes

### DIFF
--- a/src/Strategies/AbstractHashStrategy.php
+++ b/src/Strategies/AbstractHashStrategy.php
@@ -64,7 +64,7 @@ abstract class AbstractHashStrategy implements HashStrategy
 
             return $this->hashFromVipsImage($image, $bits);
         } catch (Exception $e) {
-            throw new Exception('Failed to generate hash: '.$e->getMessage());
+            throw new \RuntimeException('Failed to generate hash: '.$e->getMessage(), 0, $e);
         }
     }
 
@@ -84,7 +84,7 @@ abstract class AbstractHashStrategy implements HashStrategy
 
             return $this->hashFromVipsImage($image, $bits);
         } catch (Exception $e) {
-            throw new Exception('Failed to generate hash from buffer: '.$e->getMessage());
+            throw new \RuntimeException('Failed to generate hash from buffer: '.$e->getMessage(), 0, $e);
         }
     }
 

--- a/src/Strategies/ColorHistogramHashStrategy.php
+++ b/src/Strategies/ColorHistogramHashStrategy.php
@@ -74,7 +74,7 @@ class ColorHistogramHashStrategy extends AbstractHashStrategy
 
             return $this->hashFromVipsImage($image, $bits);
         } catch (\Exception $e) {
-            throw new \Exception('Failed to generate hash: '.$e->getMessage());
+            throw new \RuntimeException('Failed to generate hash: '.$e->getMessage(), 0, $e);
         }
     }
 
@@ -103,7 +103,7 @@ class ColorHistogramHashStrategy extends AbstractHashStrategy
 
             return $this->hashFromVipsImage($image, $bits);
         } catch (\Exception $e) {
-            throw new \Exception('Failed to generate hash from buffer: '.$e->getMessage());
+            throw new \RuntimeException('Failed to generate hash from buffer: '.$e->getMessage(), 0, $e);
         }
     }
 

--- a/src/Strategies/MashedHashStrategy.php
+++ b/src/Strategies/MashedHashStrategy.php
@@ -100,7 +100,7 @@ class MashedHashStrategy extends AbstractHashStrategy
 
             return $this->hashFromVipsImageWithGrayscale($image, $bits, $isGrayscale);
         } catch (\Exception $e) {
-            throw new \Exception('Failed to generate hash: '.$e->getMessage());
+            throw new \RuntimeException('Failed to generate hash: '.$e->getMessage(), 0, $e);
         }
     }
 
@@ -129,7 +129,7 @@ class MashedHashStrategy extends AbstractHashStrategy
 
             return $this->hashFromVipsImageWithGrayscale($image, $bits, $isGrayscale);
         } catch (\Exception $e) {
-            throw new \Exception('Failed to generate hash from buffer: '.$e->getMessage());
+            throw new \RuntimeException('Failed to generate hash from buffer: '.$e->getMessage(), 0, $e);
         }
     }
 


### PR DESCRIPTION
- Pass original exception as $previous parameter in all catch blocks
- Upgrade from generic Exception to RuntimeException (more appropriate for runtime image processing failures)
- Preserves stack traces for debugging instead of discarding them

https://claude.ai/code/session_01WX4dRKunBgmNLiFzepDdJp