### PR TITLE
Fix VIPS configuration: isolate per-strategy, fix memory units, fix R…

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,14 @@ if ($pHash->isCompatibleWith($fromHex)) {
 ```php
 // Configure VIPS settings for performance tuning
 PerceptualHash::configure([
-    'concurrency' => 4,
-    'cache_max' => 100 * 1024 * 1024, // 100MB
+    'cores' => 4,
+    'maxCacheSize' => 100,  // Max cached operations
+    'maxMemory' => 256,     // 256MB cache memory
 ]);
 
-// DHash uses the same configuration
+// Each strategy maintains its own configuration
 DHash::configure([
-    'concurrency' => 8,
+    'cores' => 8,
 ]);
 
 // Configure Color Histogram Hash quantization
@@ -209,7 +210,7 @@ ColorHistogramHash::configureQuantization(16, 8, 8); // 16 hue bins, 8 saturatio
 
 // MashedHash uses standard VIPS configuration
 MashedHash::configure([
-    'concurrency' => 4,
+    'cores' => 4,
 ]);
 ```
 
@@ -277,15 +278,15 @@ foreach ($hashes as $path1 => $hash1) {
 ```php
 // Configure for maximum performance
 PerceptualHash::configure([
-    'concurrency' => 8,              // Use 8 CPU cores
-    'cache_max' => 200 * 1024 * 1024, // 200MB cache
-    'disable_cache' => false,         // Enable caching
+    'cores' => 8,              // Use 8 CPU cores
+    'maxMemory' => 512,        // 512MB cache memory
+    'disableCache' => false,   // Enable caching
 ]);
 
-// Configure with different settings
+// Each strategy has independent configuration
 DHash::configure([
-    'concurrency' => 4,
-    'cache_max' => 100 * 1024 * 1024, // 100MB cache
+    'cores' => 4,
+    'maxMemory' => 256,        // 256MB cache memory
 ]);
 
 // Process from memory to avoid disk I/O

--- a/src/Strategies/AbstractHashStrategy.php
+++ b/src/Strategies/AbstractHashStrategy.php
@@ -12,39 +12,49 @@ use LegitPHP\HashMoney\HashValue;
 
 abstract class AbstractHashStrategy implements HashStrategy
 {
-    protected static bool $vipsInitialized = false;
+    private static array $configs = [];
 
-    protected static array $config = [
+    private static array $initialized = [];
+
+    private const DEFAULT_CONFIG = [
         'cores' => null,
-        'maxCacheSize' => 64,
-        'maxMemory' => 256,
+        'maxCacheSize' => 64,        // Max cached operations (libvips vips_cache_set_max)
+        'maxMemory' => 256,          // Max cache memory in MB (converted to bytes for libvips)
         'sequentialAccess' => true,
         'disableCache' => false,
     ];
 
     public function configure(array $config): void
     {
-        self::$config = array_merge(self::$config, $config);
+        $class = static::class;
+        self::$configs[$class] = array_merge(self::getConfig(), $config);
 
-        if (self::$vipsInitialized) {
-            self::$vipsInitialized = false;
+        if (self::$initialized[$class] ?? false) {
+            self::$initialized[$class] = false;
             $this->initVips();
         }
     }
 
+    protected static function getConfig(): array
+    {
+        return self::$configs[static::class] ?? self::DEFAULT_CONFIG;
+    }
+
     protected function initVips(): void
     {
-        if (! self::$vipsInitialized) {
-            $cores = self::$config['cores'] ?? min(8, max(2, $this->getNumCores()));
+        $class = static::class;
+        if (! (self::$initialized[$class] ?? false)) {
+            $config = self::getConfig();
+            $cores = $config['cores'] ?? min(8, max(2, $this->getNumCores()));
             Config::concurrencySet($cores);
-            Config::cacheSetMax(self::$config['maxCacheSize']);
-            Config::cacheSetMaxMem(self::$config['maxMemory']);
+            Config::cacheSetMax($config['maxCacheSize']);
+            Config::cacheSetMaxMem($config['maxMemory'] * 1024 * 1024);
 
-            if (self::$config['disableCache']) {
+            if ($config['disableCache']) {
                 Config::cacheSetMax(0);
             }
 
-            self::$vipsInitialized = true;
+            self::$initialized[$class] = true;
         }
     }
 


### PR DESCRIPTION
…EADME

- Use static::class-keyed arrays to isolate config per strategy subclass, preventing DHash::configure() from silently overwriting PerceptualHash config
- Fix maxMemory default: now stored in MB and converted to bytes internally (previous default of 256 meant 256 bytes, not 256MB)
- Fix README examples to use actual config keys (cores, maxCacheSize, maxMemory, disableCache) instead of incorrect keys (concurrency, cache_max, disable_cache)

https://claude.ai/code/session_01WX4dRKunBgmNLiFzepDdJp