### PR TITLE
Fix HashValue fromHex() prefix stripping and normalized() 64-bit over…

### DIFF
--- a/src/HashValue.php
+++ b/src/HashValue.php
@@ -144,8 +144,9 @@ final class HashValue implements JsonSerializable
      */
     public static function fromHex(string $hex, int $bits, string $algorithm, array $metadata = []): self
     {
-        $hex = ltrim($hex, '0x');
-        $hex = ltrim($hex, '0X');
+        if (str_starts_with($hex, '0x') || str_starts_with($hex, '0X')) {
+            $hex = substr($hex, 2);
+        }
 
         if (! ctype_xdigit($hex)) {
             throw new InvalidArgumentException('Invalid hexadecimal string: must contain only hex digits');
@@ -165,10 +166,7 @@ final class HashValue implements JsonSerializable
             $low = hexdec(substr($hex, 8, 8));
             $value = ($high << 32) | $low;
 
-            // Handle negative values
-            if ($high >= 0x80000000) {
-                $value = $value - (1 << 64);
-            }
+            // Bitwise operations above already produce the correct signed 64-bit value
         } else {
             $value = (int) hexdec($hex);
         }
@@ -208,10 +206,7 @@ final class HashValue implements JsonSerializable
                 }
             }
 
-            // Handle sign bit for 64-bit values
-            if ($binary[0] === '1') {
-                $value = $value - (1 << 64);
-            }
+            // Bitwise operations above already produce the correct signed 64-bit value
         } else {
             $value = bindec($binary);
         }
@@ -252,7 +247,7 @@ final class HashValue implements JsonSerializable
 
         // Handle sign for 64-bit values
         if ($bits === 64 && ord($decoded[0]) >= 0x80) {
-            $value = $value - (1 << 64);
+            $value = (int) ($value - pow(2, 64));
         }
 
         return new self($value, $bits, $algorithm, $metadata);
@@ -267,11 +262,6 @@ final class HashValue implements JsonSerializable
     {
         $bytes = '';
         $value = $this->value;
-
-        // Handle negative 64-bit values
-        if ($this->bits === 64 && $value < 0) {
-            $value = $value + (1 << 64);
-        }
 
         // Convert to bytes
         for ($i = ($this->bits / 8) - 1; $i >= 0; $i--) {
@@ -320,11 +310,6 @@ final class HashValue implements JsonSerializable
         $count = 0;
         $value = $this->value;
 
-        // Handle negative values for 64-bit
-        if ($this->bits === 64 && $value < 0) {
-            $value = $value + (1 << 64);
-        }
-
         for ($i = 0; $i < $this->bits; $i++) {
             if (($value >> $i) & 1) {
                 $count++;
@@ -370,16 +355,16 @@ final class HashValue implements JsonSerializable
      */
     public function normalized(): float
     {
-        $value = $this->value;
+        if ($this->bits === 64) {
+            // Use float math to avoid 64-bit integer overflow
+            $unsigned = $this->value < 0 ? $this->value + pow(2, 64) : (float) $this->value;
 
-        // Handle negative 64-bit values
-        if ($this->bits === 64 && $value < 0) {
-            $value = $value + (1 << 64);
+            return $unsigned / (pow(2, 64) - 1);
         }
 
         $maxValue = (1 << $this->bits) - 1;
 
-        return $value / $maxValue;
+        return $this->value / $maxValue;
     }
 
     /**

--- a/tests/HashValueEnhancedTest.php
+++ b/tests/HashValueEnhancedTest.php
@@ -351,4 +351,57 @@ describe('HashValue Enhanced Features', function () {
             }
         });
     });
+
+    describe('fromHex leading zero preservation', function () {
+        test('fromHex preserves leading zeros without prefix', function () {
+            $hash = HashValue::fromHex('00ff', 16, 'test');
+            expect($hash->getValue())->toBe(0x00FF);
+            expect($hash->toHex())->toBe('00ff');
+        });
+
+        test('fromHex with lowercase hex prefix preserves leading zeros in value', function () {
+            $hash = HashValue::fromHex('0x00ff', 16, 'test');
+            expect($hash->getValue())->toBe(0x00FF);
+            expect($hash->toHex())->toBe('00ff');
+        });
+
+        test('fromHex with uppercase hex prefix preserves leading zeros in value', function () {
+            $hash = HashValue::fromHex('0X00ff', 16, 'test');
+            expect($hash->getValue())->toBe(0x00FF);
+            expect($hash->toHex())->toBe('00ff');
+        });
+
+        test('fromHex without prefix works for values starting with x-like chars', function () {
+            // Hex value that starts with a valid hex digit but would be corrupted by ltrim character set
+            $hash = HashValue::fromHex('0000000000000001', 64, 'test');
+            expect($hash->getValue())->toBe(1);
+        });
+    });
+
+    describe('normalized 64-bit correctness', function () {
+        test('normalized returns correct value for positive 64-bit', function () {
+            $hash = new HashValue(0, 64, 'test');
+            expect($hash->normalized())->toBe(0.0);
+        });
+
+        test('normalized returns 1.0 for max unsigned 64-bit', function () {
+            // -1 in signed = all bits set = max unsigned
+            $hash = new HashValue(-1, 64, 'test');
+            expect(abs($hash->normalized() - 1.0))->toBeLessThan(0.00001);
+        });
+
+        test('normalized returns approximately 0.5 for PHP_INT_MIN', function () {
+            // PHP_INT_MIN = 0x8000000000000000 = 2^63 unsigned
+            // normalized = 2^63 / (2^64 - 1) ≈ 0.5
+            $hash = new HashValue(PHP_INT_MIN, 64, 'test');
+            expect(abs($hash->normalized() - 0.5))->toBeLessThan(0.01);
+        });
+
+        test('normalized returns value in [0,1] range for arbitrary 64-bit', function () {
+            $hash = new HashValue(12345678, 64, 'test');
+            $normalized = $hash->normalized();
+            expect($normalized)->toBeGreaterThanOrEqual(0.0);
+            expect($normalized)->toBeLessThanOrEqual(1.0);
+        });
+    });
 });


### PR DESCRIPTION
…flow

- Replace ltrim() character-set stripping with proper str_starts_with() prefix check
- Fix 64-bit overflow in normalized() using float math (1 << 64 is 0 in PHP)
- Remove dead code from fromHex(), fromBinary(), toBase64(), countSetBits() where (1 << 64) evaluations were no-ops
- Fix fromBase64() sign handling to use pow(2, 64) instead of bit shift
- Add tests for fromHex leading zero preservation and 64-bit normalized() correctness

https://claude.ai/code/session_01WX4dRKunBgmNLiFzepDdJp